### PR TITLE
fix(ci): add build step before version commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
               run: corepack enable && corepack prepare pnpm@10.10.0 --activate
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
+            - name: Build project
+              run: pnpm run build
             - name: Get next patch version
               id: version
               run: pnpm --reporter=silent next-patch-version >> $GITHUB_OUTPUT


### PR DESCRIPTION
- Add pnpm run build before next-patch-version command

- Fixes MODULE_NOT_FOUND error for dist/next-patch-version.js

- Ensures built files exist before running version commands